### PR TITLE
Add pytest deps and CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11']
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[numpy,test]
+      - name: Run tests
+        run: pytest -q

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = []
 
 [project.optional-dependencies]
 numpy = ["numpy>=1.20"]
+test = ["pytest>=7.4"]
 
 [project.urls]
 Homepage = "https://example.com"

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -1,0 +1,8 @@
+from starcoder2 import Starcoder2Tokenizer
+
+def test_encode_decode_roundtrip():
+    tok = Starcoder2Tokenizer()
+    text = "hello world"
+    ids = tok.encode(text)
+    assert tok.decode(ids) == text
+


### PR DESCRIPTION
## Summary
- include pytest as optional dependency via `[project.optional-dependencies.test]`
- create a simple tokenizer roundtrip test
- add GitHub Actions workflow to install dependencies and run the tests

## Testing
- `pytest -q`