### PR TITLE
Implement BPE tokenizer

### DIFF
--- a/starcoder2/tokenizer.py
+++ b/starcoder2/tokenizer.py
@@ -1,24 +1,131 @@
 import json
-from typing import List
+import os
+from typing import Dict, List, Tuple, Iterable
+
+try:
+    import numpy as np
+except ImportError:  # optional dependency
+    np = None
 
 
 class Starcoder2Tokenizer:
-    """A very small whitespace tokenizer as a placeholder."""
+    """Byte Pair Encoding tokenizer with optional numpy usage."""
 
-    def __init__(self):
-        self.vocab = {}
-        self.inv_vocab = {}
+    def __init__(self, vocab: Dict[str, int] = None, merges: Iterable[Tuple[str, str]] = None):
+        self.vocab: Dict[str, int] = vocab or {}
+        self.inv_vocab: Dict[int, str] = {i: tok for tok, i in self.vocab.items()}
+        self.merges = list(merges) if merges else []
+        # rank of merge pairs for fast lookup
+        self.bpe_ranks: Dict[Tuple[str, str], int] = {
+            tuple(pair): idx for idx, pair in enumerate(self.merges)
+        }
+        self.cache: Dict[str, List[str]] = {}
+
+    # ------------------------------------------------------------------
+    # helper utilities
+    @staticmethod
+    def _get_pairs(tokens: List[str]) -> set:
+        """Return set of adjacent token pairs."""
+        pairs = set()
+        for i in range(len(tokens) - 1):
+            pairs.add((tokens[i], tokens[i + 1]))
+        return pairs
+
+    def _bpe(self, token: str) -> List[str]:
+        if token in self.cache:
+            return self.cache[token]
+
+        if not self.bpe_ranks:
+            # no merges defined -> return characters
+            result = list(token)
+            self.cache[token] = result
+            return result
+
+        word = list(token)
+        pairs = self._get_pairs(word)
+        while pairs:
+            # select candidate pair with smallest rank
+            min_pair = None
+            min_rank = None
+            for p in pairs:
+                r = self.bpe_ranks.get(p)
+                if r is not None and (min_rank is None or r < min_rank):
+                    min_pair = p
+                    min_rank = r
+            if min_pair is None:
+                break
+            first, second = min_pair
+            new_word = []
+            i = 0
+            while i < len(word):
+                try:
+                    j = word.index(first, i)
+                except ValueError:
+                    new_word.extend(word[i:])
+                    break
+                new_word.extend(word[i:j])
+                if j < len(word) - 1 and word[j + 1] == second:
+                    new_word.append(first + second)
+                    i = j + 2
+                else:
+                    new_word.append(word[j])
+                    i = j + 1
+            word = new_word
+            if len(word) == 1:
+                break
+            pairs = self._get_pairs(word)
+
+        self.cache[token] = word
+        return word
+
+    # ------------------------------------------------------------------
+    @classmethod
+    def from_file(cls, vocab_file: str, merges_file: str) -> "Starcoder2Tokenizer":
+        """Load tokenizer vocabulary and merges from files."""
+        with open(vocab_file, "r", encoding="utf-8") as vf:
+            vocab = json.load(vf)
+
+        merges = []
+        with open(merges_file, "r", encoding="utf-8") as mf:
+            for line in mf:
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                parts = line.split()
+                if len(parts) == 2:
+                    merges.append((parts[0], parts[1]))
+
+        return cls(vocab=vocab, merges=merges)
+
+    @classmethod
+    def from_pretrained(cls, directory: str) -> "Starcoder2Tokenizer":
+        """Load ``vocab.json`` and ``merges.txt`` from a directory."""
+        vocab_path = os.path.join(directory, "vocab.json")
+        merges_path = os.path.join(directory, "merges.txt")
+        return cls.from_file(vocab_path, merges_path)
+
+    # ------------------------------------------------------------------
+    def _token_to_id(self, token: str) -> int:
+        if token not in self.vocab:
+            idx = len(self.vocab)
+            self.vocab[token] = idx
+            self.inv_vocab[idx] = token
+        return self.vocab[token]
 
     def encode(self, text: str) -> List[int]:
-        tokens = text.split()
-        ids = []
-        for token in tokens:
-            if token not in self.vocab:
-                idx = len(self.vocab)
-                self.vocab[token] = idx
-                self.inv_vocab[idx] = token
-            ids.append(self.vocab[token])
+        tokens: List[str] = []
+        words = text.split()
+        for i, word in enumerate(words):
+            piece = word if i == 0 else "Ġ" + word
+            tokens.extend(self._bpe(piece))
+
+        ids = [self._token_to_id(t) for t in tokens]
+        if np is not None:
+            return np.array(ids, dtype=np.int64).tolist()
         return ids
 
     def decode(self, ids: List[int]) -> str:
-        return " ".join(self.inv_vocab.get(i, "") for i in ids)
+        tokens = [self.inv_vocab.get(i, "") for i in ids]
+        text = "".join(tokens)
+        text = text.replace("Ġ", " ")
+        return text

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -1,3 +1,4 @@
+import json
 from starcoder2 import Starcoder2Tokenizer
 
 def test_encode_decode_roundtrip():
@@ -5,4 +6,39 @@ def test_encode_decode_roundtrip():
     text = "hello world"
     ids = tok.encode(text)
     assert tok.decode(ids) == text
+
+
+def test_bpe_from_files(tmp_path):
+    vocab = {
+        "hello": 0,
+        "Ġworld": 1,
+        "h": 2,
+        "e": 3,
+        "l": 4,
+        "o": 5,
+        "Ġ": 6,
+        "w": 7,
+        "r": 8,
+        "d": 9,
+    }
+    merges = [
+        "h e",
+        "he l",
+        "hel l",
+        "hell o",
+        "Ġ w",
+        "Ġw o",
+        "Ġwo r",
+        "Ġwor l",
+        "Ġworl d",
+    ]
+    vocab_file = tmp_path / "vocab.json"
+    merges_file = tmp_path / "merges.txt"
+    vocab_file.write_text(json.dumps(vocab))
+    merges_file.write_text("\n".join(merges))
+
+    tok = Starcoder2Tokenizer.from_pretrained(tmp_path)
+    ids = tok.encode("hello world")
+    assert ids == [0, 1]
+    assert tok.decode(ids) == "hello world"
 


### PR DESCRIPTION
## Summary
- implement a byte pair encoding tokenizer with optional numpy usage
- add loading helpers (`from_file` and `from_pretrained`)
- update encode/decode to work on subword tokens
- add tests for BPE loading from files

## Testing
- `pytest -q`